### PR TITLE
Fixed drush and drupal console installation

### DIFF
--- a/.docker/www/Dockerfile
+++ b/.docker/www/Dockerfile
@@ -54,8 +54,13 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 
 # Install Drush
 RUN composer global require drush/drush:8.x
-RUN cd /var/www/html && composer require drupal/console:~1.0 --prefer-dist --optimize-autoloader
-ENV PATH "$PATH:/root/.composer/vendor/bin/:/var/www/.composer/vendor/bin/"
+RUN mv /root/.composer/ /var/www/.composer
+ENV PATH="$PATH:/var/www/.composer/vendor/bin"
+
+# Install Drupal Console
+RUN curl https://drupalconsole.com/installer -L -o drupal.phar \
+&& mv drupal.phar /usr/local/bin/drupal \
+&& chmod +x /usr/local/bin/drupal
 
 # Install PHPMyAdmin
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y phpmyadmin


### PR DESCRIPTION
## Issue
Docker was installing all ```composer require``` in ```/root/.composer/vendor/bin``` but ```www-data``` couldn't execute it.

## Solution
* Install Drupal Console launcher instead with Composer
* Install Drush with Composer and move dir ```/root/.composer```to ```/var/www/.composer``` and edit PATH to point ```vendor/bin```dir.

## Test
Execute ```sh ddrush```and ```sh ddrupal``` return command help list