### PR TITLE
Fixed custom docker commands

### DIFF
--- a/.docker/bin/docker-drupal
+++ b/.docker/bin/docker-drupal
@@ -2,4 +2,4 @@
 
 ## Use this command to exec drupal console within apache service
 
-docker-compose exec -u www-data www "$@"
+docker-compose exec -u www-data www drupal "$@"

--- a/.docker/bin/docker-symlinks-down
+++ b/.docker/bin/docker-symlinks-down
@@ -30,8 +30,8 @@ if [ -L 'dcomposer' ]; then
 unlink dcomposer
 fi
 
-if [ -L 'dconsole' ]; then
-unlink dconsole
+if [ -L 'ddrupal' ]; then
+unlink ddrupal
 fi
 
 if [ -L 'dnpm' ]; then

--- a/.docker/bin/docker-symlinks-up
+++ b/.docker/bin/docker-symlinks-up
@@ -37,10 +37,10 @@ unlink dcomposer
 fi
 ln -s .docker/bin/docker-composer dcomposer
 
-if [ -L 'dconsole' ]; then
-unlink dconsole
+if [ -L 'ddrupal' ]; then
+unlink ddrupal
 fi
-ln -s .docker/bin/docker-console dconsole
+ln -s .docker/bin/docker-drupal ddrupal
 
 if [ -L 'dnpm' ]; then
 unlink dnpm


### PR DESCRIPTION
## Issue
```docker-console``` script was not executing Drupal Console

## Solution
* Add command ```drupal``` to the ```docker-compose exec```
* Rename ```docker-console```to ```docker-drupal````
* Rename symlinks
* Edit symlinks scripts

## Test
Run ```sh ddrupal``` has to exec drupal console.